### PR TITLE
Turkish translation

### DIFF
--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -564,7 +564,7 @@
     <string name="Reject_Invitation">"Daveti Reddet"</string>
     <string name="Leave_Game">"Oyundan ayrıl"</string>
     <string name="Remove_Friend">"Arkadaşı kaldır"</string>
-    <string name="Remove_Clan_Member">"Üyesini Çıkar"</string>
+    <string name="Remove_Clan_Member">"Klan üyesini Çıkar"</string>
     <string name="Flag_lobby_as_inappropriate">"Bu lobiyi uygunsuz olarak işaretle"</string>
     <string name="Promote_Clan_Member">"Klan Üyesinin Rütbesini Yükselt"</string>
     <string name="Leave_Clan">"Klandan ayrıl"</string>
@@ -1413,7 +1413,7 @@ Oturum açmak istemiyorsanız, tek oyunculu oynamaya devam edebilirsiniz."
         <item>"Küçük"</item>
         <item>"Normal"</item>
         <item>"Büyük"</item>
-        <item>"HUGE"</item>
+        <item>"DEVASA"</item>
     </string-array>
 
     <string-array name="clan_war_sizes">


### PR DESCRIPTION
Hello, the clan history is still in English, the members who joined, the people who left the clan, their text is not written in Turkish, that may have been overlooked.

I would be very grateful if I could get a translator tag. I would like to translate the things that I see wrong and need to be added. Thank you in advance. Best regards


My game Id : 18730728
discord name : deniz_dev