### PR TITLE
Update strings.xml

### DIFF
--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -58,8 +58,8 @@
     <string name="SERVER">"SERVEUR"</string>
     <string name="Joining_game_in_">"Rejoindre la partie "</string>
     <string name="Game_Full">"Partie complète"</string>
-    <string name="US_East">"Amérique Centrale"</string>
-    <string name="US_West">"Amérique du Nord"</string>
+    <string name="US_East">"Etats-Unis de l'Est"</string>
+    <string name="US_West">"Etats-Unis de l'Ouest"</string>
     <string name="Europe">"Europe"</string>
     <string name="South_America">"Amérique du Sud"</string>
 
@@ -1382,10 +1382,10 @@ Commandes:
 
 Si vous ne souhaitez pas vous connecter, vous pouvez toujours jouer en mode solo."
     </string>
-    <string name="_2x_skin_resolution">2x résolution de la skin</string>
+    <string name="_2x_skin_resolution">2x résolution du skin</string>
     <string name="pm">PM</string>
     <string name="You_are_already_friends_">Vous êtes déjà amis.</string>
-    <string name="Account_must_be_1_day_old_to_send_mail_">Le compte doit avoir 1 jour pour pouvoir envoyer du courrier.</string>
+    <string name="Account_must_be_1_day_old_to_send_mail_">Le compte doit avoir 1 jour pour pouvoir envoyer un mail.</string>
     <string name="Translator">Traducteur</string>
 
     <string-array name="control_modes">


### PR DESCRIPTION
Some corrections of translations

The word "COURRIEL" is correct by using google translation however in France few people use it, it is a commonly used word, this why i prefer that we put "MAIL" instead it is a word often used. The word is already translated as MAIL so it's better to leave it like that

"resolution de la skin" is false, i don't know who translated it but it's not said at all

The word US was translated as America ( US east was translated as central america and west as north america i don't know why ), i corrected that.