### PR TITLE
Update Swedish sv language

### DIFF
--- a/res/values-sv/strings.xml
+++ b/res/values-sv/strings.xml
@@ -35,7 +35,7 @@
     <string name="_Alias_">" Alias "</string>
     <string name="_Score_">" Poäng "</string>
     <string name="Score__">" Poäng: "</string>
-    <string name="Recombine_">" Sätt ihop: "</string>
+    <string name="Recombine_">" Sätts ihop: "</string>
     <string name="WINNER_">"Vinnare:"</string>
     <string name="IDLE">"Frånvarande"</string>
     <string name="Name_Invalid_">"Ogiltligt namn."</string>
@@ -43,7 +43,7 @@
     <string name="CONNECTED">"Ansluten"</string>
     <string name="JOINING___">"Ansluter…"</string>
     <string name="PLAYING">"Spelar"</string>
-    <string name="MULTIPLAYER">"Multiplayer"</string>
+    <string name="MULTIPLAYER">"Flerspelarläge"</string>
 
     <string name="JOIN">"Anslut"</string>
 
@@ -104,7 +104,7 @@
     <string name="Single_Player_Stats">"Enspelarstatistik"</string>
 
     <string name="Level">"Nivå"</string>
-    <string name="PAUSED">"Paus"</string>
+    <string name="PAUSED">"Pausad"</string>
 
 
     <string name="FRIENDS">"Vänner"</string>


### PR DESCRIPTION
Row 38 has incorrect grammar, change from "Sätt ihop" to "Sätts ihop"  Row 46 had an english word "Multiplayer" it's "Flerspelarläge" in Swedish.
"Paused" is going from "Paus" to "Pausad" in Swedish, since "Paus"is not a word in this context. Paus is more like: Timeout.
Thanks.

My Nebulous ID:
18273864