### PR TITLE
Update Korean language

### DIFF
--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -313,7 +313,7 @@
     <string name="Survive_but_do_not_win_a_survival_game_">"생존했지만 생존게임에서 패배하기"</string>
     <string name="Win_by_8_points_in_a_Soccer_game_">"축구 경기에서 8 점 이상으로 승리."</string>
     <string name="Score_3_goals_in_a_single_Soccer_game_">"한 번의 축구 게임에서 3 점 획득"</string>
-    <string name="Total_Domination">"총 점령"</string>
+    <string name="Total_Domination">"완전한 지배"</string>
     <string name="Win_500_games_of_any_type_">"종류에 상관없이 500번 승리"</string>
     <string name="Translations">"번역자"</string>
     <string name="Developers">"개발자"</string>


### PR DESCRIPTION
The original translation, "총 점령", is closer to meaning the total sum of occupations rather than Total Domination. Therefore, a more natural translation in Korean would be "완전한 지배'.

My nebulous ID is 20039042 
Thank you for your service.