### PR TITLE
Update Actualizar el idioma español

### DIFF
--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -182,7 +182,7 @@
     <string name="Self_Contained">"Autónomo"</string>
     <string name="Survivalist">"Superviviente"</string>
     <string name="Ultramassive">"Ultramasivo"</string>
-    <string name="Rapid_Ascension">"Ascenso Rápida"</string>
+    <string name="Rapid_Ascension">"Ascenso Rápido"</string>
     <string name="Revenge">"Venganza"</string>
     <string name="Doge_Pound">"Engullidor de Doges"</string>
 
@@ -276,7 +276,7 @@
     <string name="ELDER">"VETERANO"</string>
 
 
-    <string name="Not_in_a_clan_">"Sin clan "</string>
+    <string name="Not_in_a_clan_">"Sin clan"</string>
 
 
     <string name="CLAN">"CLAN"</string>


### PR DESCRIPTION
Eh encontrado algunos errores con respecto a la traducción al español y me gustaría que fueran corregidas con el fin de que los demás jugadores puedan disfrutar el juego en sus idiomas materno 

Por ejemplo: "Sin clan " tiene un espacio adicional debe de ser "sin clan)

Otra corrección que también  hice fue cambiar: "Ascenso Rápida" debería ser "Ascenso Rápido", ya que "Ascenso" es un sustantivo masculino  Dejaré mi ID para esperar la etiqueta "Traductores" mientras seguiré buscando defectos en el código y si ese fuera el caso les informaré de inmediato con su respectiva corrección. Mi ID: 22647834