### PR TITLE
New Update Spanish (Latin America)

### DIFF
--- a/res/values-b+es+r419/strings.xml
+++ b/res/values-b+es+r419/strings.xml
@@ -1339,7 +1339,7 @@ Subir la misma skin NO aprobada varias veces resultará en más sanciones o en u
     <string name="PLAY_SOLO">JUGAR SOLO</string>
     <string name="SET_EMOTE">ESTABLECER EMOTICONO</string>
     <string name="Winner_Winner_Chicken_Dinner">¡¡Quien Parte y Reparte se Lleva la Mejor Parte!!</string>
-    <string name="Win_a_Battle_Royale_">Gana una Batalla Reak.</string>
+    <string name="Win_a_Battle_Royale_">Gana una Batalla Real.</string>
     <string name="Battle_">¡Batalla!</string>
     <string name="BATTLE_ROYALE">BATALLA REAL</string>
     <string name="Battle_Royale">Batalla Real</string>


### PR DESCRIPTION
ID Nebulous: 3119626 
Discord User: theodxrius

Corrected errors: inconsistency with uppercase and lowercase letters, poorly written texts and incorrect grammar, mistyped letters, correction of punctuation in numbers, for example (1.000 incorrect, 1,000 correct), words in English that are used exactly the same in Latin America, such as the word “zombie”.

Translation of (mayhem) to spanish as “modo caos”, correction of the warning that appears when you invite a player who is not online, and other words that needed to be translated from English to Spanish, correction of the label (COMP BANNED), the section (Message private), etc.

correction of the word "XP" in Spanish (EXPERIENCIA) which is summarized in EXP, and correction of the position of the multiplied number "2x, 3x, 4x and 5x).