### PR TITLE
Update values-ja (Japanese) [RE-SENT PULL REQUEST]

### DIFF
--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -428,10 +428,10 @@
     <string name="Purchase_Successful_">"購入に成功しました"</string>
     <string name="You_may_need_to_reconnect_to_use_the_purchase_">"購入した商品をお使いになるためには再接続が必要です。"</string>
     <string name="Confirm_Purchase">"購入を確認する"</string>
-    <string name="x3_XP_24_hours">"1日間、3倍の経験値"</string>
-    <string name="x3_XP_1_Hour">"1時間間、3倍の経験値"</string>
-    <string name="x2_XP_24_Hour">"1日間、2倍の経験値"</string>
-    <string name="x2_XP_1_Hour">"1時間間、2倍の経験値"</string>
+    <string name="x3_XP_24_hours">"経験値3倍24時間"</string>
+    <string name="x3_XP_1_Hour">"経験値3倍1時間"</string>
+    <string name="x2_XP_24_Hour">"経験値2倍24時間"</string>
+    <string name="x2_XP_1_Hour">"経験値2倍1時間"</string>
     <string name="Cost_">"価格："</string>
     <string name="You_cannot_purchase_this_right_now_">"この商品はいま購入できません。"</string>
 
@@ -846,17 +846,17 @@
     <string name="Speed_Painter">"スピードペインタ"</string>
     <string name="Win_a_Paint_game_with_all_opponents_having_0_score_">"0スコアの相手にペイントゲームで勝ちます。"</string>
     <string name="Win_a_Paint_game_in_60_seconds_or_less_">"60秒以内にペイントゲームで勝ちます。"</string>
-    <string name="Autoclick">"自動クリック"</string>
-    <string name="Autoclick_24_Hours">"24時間を自動クリック"</string>
-    <string name="Autoclick_1_Hour">"自動クリック 1時間"</string>
-    <string name="Ultraclick_24_Hours">"ウルトラクリック 24時間"</string>
-    <string name="Ultraclick_1_Hour">"ウルトラクリック 1時間"</string>
+    <string name="Autoclick">"オートクリック"</string>
+    <string name="Autoclick_24_Hours">"オートクリック24時間"</string>
+    <string name="Autoclick_1_Hour">"オートクリック1時間"</string>
+    <string name="Ultraclick_24_Hours">"ウルトラクリック24時間"</string>
+    <string name="Ultraclick_1_Hour">"ウルトラクリック1時間"</string>
     <string name="Ultraclick">"ウルトラクリック"</string>
     <string name="May_Reduce_Lag">"（ラグを減少させることができます）"</string>
-    <string name="Ultraclick_Permanent">"ウルトラクリックパーマネント"</string>
-    <string name="Autoclick_Permanent">"自動クリックパーマネント"</string>
-    <string name="x3_XP_Permanent">"経験値3倍パーマネント"</string>
-    <string name="x2_XP_Permanent">"経験値2倍パーマネント"</string>
+    <string name="Ultraclick_Permanent">"永久にウルトラクリック"</string>
+    <string name="Autoclick_Permanent">"永久にオートクリック"</string>
+    <string name="x3_XP_Permanent">"永久に経験値3倍"</string>
+    <string name="x2_XP_Permanent">"永久に経験値2倍"</string>
     <string name="Permanent">"恒久的な"</string>
     <string name="Apply_To_Account">"アカウントに適用"</string>
     <string name="Spin_">"スピンする"</string>
@@ -926,9 +926,9 @@
     <string name="Invitation_accepted_">招待が受け入れられました！</string>
     <string name="Invitation_expired_">招待状の期限が切れました</string>
     <string name="Wait_for_the_current_invitation_to_expire_">先ほど送った招待状の期限が切れるまでお待ちください。</string>
-    <string name="BLOB_COLOR">枠の色</string>
-    <string name="ENABLED">有効にする</string>
-    <string name="Enable_Custom_Blob_Color">枠のカスタムカラー購入しますか？</string>
+    <string name="BLOB_COLOR">ブロブの色</string>
+    <string name="ENABLED">ON</string>
+    <string name="Enable_Custom_Blob_Color">ブロブのカスタム色を有効にする</string>
     <string name="Choose_Menu">メニューを選択</string>
     <string name="SPECTATE">観戦</string>
     <string name="INVITE">招待する</string>
@@ -977,7 +977,7 @@
     <string name="COPY">コピー</string>
     <string name="_1v1_Ultra">1対1ウルトラ</string>
     <string name="ArenaDescriptionUltra">勝者は%sプラズマ獲得できます</string>
-    <string name="BANNED">禁止プレイヤー</string>
+    <string name="BANNED">禁止すれた</string>
     <string name="CLAN_MEMBERS">クランメンバー</string>
     <string name="CLAN_REQUESTS">クラン加入申請</string>
     <string name="Pet_1">ペット1</string>
@@ -1027,7 +1027,7 @@
     <string name="POSITION_EJECT_BUTTON">位置イジェクトボタン</string>
     <string name="POSITION_EJECT_TOGGLE_BUTTON">位置イジェクトトグルボタン</string>
     <string name="WIFI">WI-FI</string>
-    <string name="JOIN_IP">ジョイン IP</string>
+    <string name="JOIN_IP">IPに参加する</string>
     <string name="Specify_Host_IP">ホストIPを指定する</string>
     <string name="ADVANCED_SETUP">詳細設定</string>
     <string name="WORLD_CUP_EVENT___">世界イベント！</string>
@@ -1067,7 +1067,7 @@
     <string name="TRICK_SPLIT">TRICK SPLIT</string>
     <string name="POP_SPLIT">POP SPLIT</string>
     <string name="PUSH_SPLIT">PUSH SPLIT</string>
-    <string name="Level_Colors">Level Colors</string>
+    <string name="Level_Colors">レベルの色</string>
     <string name="click_info">Autoclick / Ultraclick do not work in FFA Classic!</string>
     <string name="Hooked">Hooked</string>
     <string name="Be_pulled_by_a_hookshot_spell_for_10_seconds">Be pulled by a hookshot spell for 10 seconds</string>
@@ -1086,13 +1086,14 @@
     <string name="Channel">チャンネル</string>
     <string name="Choose_Text_Size">Choose Text Size</string>
     <string name="LEVEL_COLOR">レベルの色</string>
+    <string name="level_color_instructions" translatable="true">あなたのレベルの色を選択して。</string>
     <string name="INITIATE">INITIATE</string>
-    <string name="x3_Clan_XP_Perm">クラン経験値3倍永久に！</string>
-    <string name="x2_Clan_XP_Perm">クラン経験値2倍永久に！</string>
+    <string name="x3_Clan_XP_Perm">永久にクラン経験値3倍！</string>
+    <string name="x2_Clan_XP_Perm">永久にクラン経験値2倍！</string>
     <string name="Japan">日本</string>
     <string name="South_Korea">韓国</string>
     <string name="Asia">アジア</string>
-    <string name="SET_PRIVACY">プライバシーを設定</string>
+    <string name="SET_PRIVACY">プライバシーを設定する</string>
     <string name="ANIMATION">ANIMATION</string>
     <string name="Color_Cycle">Color Cycle</string>
     <string name="Fast">Fast</string>
@@ -1131,22 +1132,22 @@
     <string name="Time_">Time:</string>
     <string name="Show_Session_Stats">Show Session Stats</string>
     <string name="VALENTINES_DAY">"バレンタインデー"</string>
-    <string name="Giveaways_">Giveaways!</string>
+    <string name="Giveaways_">抽選！</string>
     <string name="Max_XP_Chain_">Max XP Chain:</string>
     <string name="POSITION_CANCEL_BUTTON">POSITION CANCEL BUTTON</string>
     <string name="INVISIBILITY">INVISIBILITY</string>
-    <string name="Set_Skin">Set Skin</string>
-    <string name="Primary">Primary</string>
-    <string name="Secondary">Secondary</string>
-    <string name="Both">Both</string>
+    <string name="Set_Skin">スキンを設定する</string>
+    <string name="Primary">ブロブ1</string>
+    <string name="Secondary">ブロブ2</string>
+    <string name="Both">両方</string>
 
-    <string name="Enable__Multiskin">"Enable\nMultiskin"</string>
-    <string name="MULTISKIN">MULTISKIN</string>
-    <string name="DISABLED">DISABLED</string>
+    <string name="Enable__Multiskin">"マルチスキン\nを有効にする"</string>
+    <string name="MULTISKIN">マルチスキン</string>
+    <string name="DISABLED">OFF</string>
 
-    <string name="Refund__Multiskin">Refund\nMultiskin</string>
+    <string name="Refund__Multiskin">マルチスキン\nを返金する</string>
     <string name="Invalid_Clan_ID_">Invalid clan ID.</string>
-    <string name="MUTED">MUTED</string>
+    <string name="MUTED">ミュートすれた</string>
     <string name="SKIN">スキン</string>
     <string name="Choose_Skin_Size">Choose Skin Size</string>
     <string name="Other_players_will_not_be_able_to_hear_you_">Other players will not be able to hear you!</string>
@@ -1157,18 +1158,18 @@
     <string name="REMOVE_SKIN_FROM_COMMUNITY_">REMOVE SKIN FROM COMMUNITY!</string>
     <string name="This_cannot_be_undone_">This cannot be undone!</string>
     <string name="watch_a_video_to_get_a_temporary_boost_for_x_life_">Watch a video to get a temporary boost for %d lives!</string>
-    <string name="WATCH_VIDEO_">WATCH VIDEO!</string>
-    <string name="PERMANENT_BOOSTS">PERMANENT BOOSTS</string>
+    <string name="WATCH_VIDEO_">ビデオを見る！</string>
+    <string name="PERMANENT_BOOSTS">永久にブースト</string>
     <string name="Video_failed_to_load_">Video failed to load!</string>
-    <string name="Video_Ready_">Video Ready!</string>
-    <string name="GIVE_PLASMA">GIVE PLASMA</string>
+    <string name="Video_Ready_">ビデオができています！</string>
+    <string name="GIVE_PLASMA">プラズマを送る</string>
     <string name="Specify_amount_">Specify amount:</string>
     <string name="Specify_amount_again_to_confirm_">Specify amount again to confirm:</string>
     <string name="Amounts_did_not_match_">Amounts did not match!</string>
     <string name="RECEIVE_PLASMA">RECEIVE PLASMA</string>
-    <string name="MULTIBLOB">MULTIBLOB</string>
-    <string name="Play_Nebulous_For_1_Year_">Play Nebulous For 1 Year!</string>
-    <string name="Play_Nebulous_For_X_Years_">Play Nebulous For %d Years!</string>
+    <string name="MULTIBLOB">マルチブロブ</string>
+    <string name="Play_Nebulous_For_1_Year_">1年間ネビュラスをプレイしました！</string>
+    <string name="Play_Nebulous_For_X_Years_">%d年間ネビュラスをプレイしました！</string>
     <string name="Starting___">Starting…</string>
     <string name="Tournament_Starting">Tournament Starting</string>
     <string name="Max_Tilt_Angle_3D_">Max Tilt Angle 3D:</string>
@@ -1213,14 +1214,14 @@
     <string name="SUPPORTER">VIP</string>
     <string name="CONQUEROR">CONQUEROR</string>
     <string name="TRICKY">トリッキ</string>
-    <string name="x4_XP_Permanent">4x XP Permanent</string>
-    <string name="x4_XP_24_hours">4x XP 24 Hours</string>
-    <string name="x4_XP_1_Hour">4x XP 1 Hour</string>
+    <string name="x4_XP_Permanent">永久に経験値4倍</string>
+    <string name="x4_XP_24_hours">経験値4倍24時間</string>
+    <string name="x4_XP_1_Hour">経験値4倍1時間</string>
     <string name="Quad">Quadruple</string>
     <string name="Middle_East">中東</string>
-    <string name="XP_4x">XP 4x</string>
-    <string name="You_cannot_play_for_x_minutes_">You cannot play for %d minutes.</string>
-    <string name="x4_Clan_XP_Perm">クラン経験値4倍永久に！</string>
+    <string name="XP_4x">経験値4倍</string>
+    <string name="You_cannot_play_for_x_minutes_">あなたは%d分にプレイしません。</string>
+    <string name="x4_Clan_XP_Perm">永久にクラン経験値4倍！</string>
     <string name="x4_Clan_XP_7_days">クラン経験値4倍7日間</string>
     <string name="x4_Clan_XP_1_Day">クラン経験値4倍1日間</string>
     <string name="CHARGE_UP">CHARGE UP</string>
@@ -1230,10 +1231,10 @@
     <string name="Crocodile_Hunter">Crocodile Hunter</string>
     <string name="Get_A_Pet_To_Level_X_">Get A Pet To Level %d.</string>
     <string name="plasma_boost_info">"You gain three times plasma from all IN-GAME sources while the boost is active! This includes arena  and tournament winnings! Does NOT work on plasma purchases, spins, or special rewards."</string>
-    <string name="Plasma_Boost_7_Days_">Plasma Boost 7 Days!!!</string>
-    <string name="Plasma_Boost_1_Day_">Plasma Boost 1 Day!</string>
-    <string name="Plasma_Boost_2_Hours_">Plasma Boost 2 Hours.</string>
-    <string name="Plasma_Boost">Plasma Boost</string>
+    <string name="Plasma_Boost_7_Days_">プラズマブースト7日間！！</string>
+    <string name="Plasma_Boost_1_Day_">プラズマブースト1日間！</string>
+    <string name="Plasma_Boost_2_Hours_">プラズマブースト2時間</string>
+    <string name="Plasma_Boost">プラズマブースト</string>
     <string name="particle_info">You must be at least level 50 and use a base skin with particles in order to see any particles.</string>
     <string name="Plain_Score_Text">"Plain Score Text"</string>
     <string name="Custom_Skin_Reviewed_Notification">Your Custom Skin Has Been Reviewed!</string>
@@ -1256,7 +1257,7 @@
     <string name="Battle_Royale">Battle Royale</string>
     <string name="The_winner_will_receive_x_plasma_">The winner will receive %s plasma!</string>
     <string name="admin_commands">"
-コマンド:
+コマンド：
 !kick [0–31]
 !reset
 !welcome {message}
@@ -1295,13 +1296,13 @@
     <string name="FREE">無料</string>
     <string name="x5_Clan_XP_1_Day">クラン経験値5倍1日間</string>
     <string name="x5_Clan_XP_7_days">クラン経験値5倍7日間</string>
-    <string name="x5_Clan_XP_Perm">クラン経験値5倍永久に！</string>
+    <string name="x5_Clan_XP_Perm">永久にクラン経験値5倍！</string>
     <string name="Quin">5X</string>
-    <string name="x5_XP_1_Hour">5X XP 1 HOUR</string>
-    <string name="x5_XP_24_hours">5X XP 24 HOURS</string>
-    <string name="x5_XP_Permanent">5X XP PERMANENT</string>
-    <string name="CAMPAIGN_2">CAMPAIGN 2</string>
-    <string name="XP_5x">XP 5x</string>
+    <string name="x5_XP_1_Hour">経験値5倍1時間</string>
+    <string name="x5_XP_24_hours">経験値5倍24時間</string>
+    <string name="x5_XP_Permanent">永久に経験値5倍</string>
+    <string name="CAMPAIGN_2">キャンペーン2</string>
+    <string name="XP_5x">経験値5倍</string>
     <string name="India">インディア</string>
     <string name="Tutorial">Tutorial</string>
     <string name="TYCOON">TYCOON</string>


### PR DESCRIPTION
### Urgent changes
1. パーマネント (Permanent): It's a correct term, but I think it's very literal by using katakana. According to all the researches I made, 永久に (/ēkyū ni/) is more appropriate in this case;
2. At string line 1030, the ジョイン (Join) was also very literal, so I had to change it to "traditional" literature (with use of kanjis + verb stablished);
3. At string line 929, it was been stablished the kanji "枠", that means "box", which doesn't make sense, so I changed to ブロブ (blob).

### Other changes
1. Changed the 永久に position from end to start, to meet with the Japanese structure order;
2. Translated more strings;
3. In コマンド (commands), I've fixed the double dot to ideographic literature;
4. Added a missing string compared to the `res/values`, it appears at line 1089 + already translated it to an approximate understandable way.
5. At line 930, it was been stablished a wrong translation. Since in English it is "ENABLED", in Japanese it was a "to enable" verb without any kind of tense, so I changed it to "ON" (turned **on**);
6. At line 931, it was been stablished a wrong translation, according to the English values. It wasn't really supposed to be a question (represented by "か？"), so I changed it to an accurate phrase + changed from "枠のカスタムカラー" (/waku no kasutamu karā/) to "ブロブのカスタム色" (/burobu no kasutamu iro/) to stablish an accurate reading.