### PR TITLE
Update strings.xml

### DIFF
--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -42,7 +42,7 @@
     <string name="Name_Invalid_">"Nom no vàlid."</string>
     <string name="Name_Taken_">"Nom en ús."</string>
     <string name="CONNECTED">"CONNECTAT"</string>
-    <string name="JOINING___">"UNINT…"</string>
+    <string name="JOINING___">"UNINT…" </string>
     <string name="PLAYING">"JUGANT"</string>
     <string name="MULTIPLAYER">"MULTIJUGADOR"</string>
 


### PR DESCRIPTION
Aquí tienes un error en la traducción:

**Casilla**: `<string name="JOINING___">"UNINT…"</string>`

**Error**: La palabra "UNINT" no es correcta en catalán.

**Corrección**: Debería ser `"UNINT…"`, que significa "Uniéndose...".

Podrías corregirlo de la siguiente manera:

```xml
<string name="JOINING___">"UNINT…" </string>
```

Esto asegura que la palabra tenga sentido en el contexto del archivo de traducción.

ID: 22647834