### PR TITLE
Update Bulgarian bg Language

### DIFF
--- a/res/values-bg/strings.xml
+++ b/res/values-bg/strings.xml
@@ -392,9 +392,9 @@
     <string name="The_next_season_begins">"Следващият сезон започва"</string>
 
     <string name="Current">"Ток"</string>
-    <string name="leaves_">"Листа."</string>
+    <string name="leaves_">"листа."</string>
     <string name="Leaf_Collector">"Събирач на Листа"</string>
-    <string name="Collect_1000_leaves_">"Събирайте 1000 Листа."</string>
+    <string name="Collect_1000_leaves_">"Събирайте 1000 листа."</string>
     <string name="XP_Boost">"XP Boost"</string>
     <string name="Double">"Двойно"</string>
     <string name="Hour">"Час"</string>


### PR DESCRIPTION
Translating some texts and correcting some clerical errors

For example, in line 395, the word Leaves, was translated to “оставя” meaning leave, Meaning the boy leaves the classroom (an example of its meaning) . It was modified to “листа” meaning leaf. 

