### PR TITLE
Update español Latín America

### DIFF
--- a/res/values-b+es+r419/strings.xml
+++ b/res/values-b+es+r419/strings.xml
@@ -1129,7 +1129,7 @@ Esta es una lista de cosas * PROHIBIDAS * en las skins personalizadas; si compra
     <string name="Pack">Paquete</string>
     <string name="Skin_Pack">Paquete de Skins</string>
     <string name="SKIN_PACK">PAQUETE DE SKIN</string>
-    <string name="HALLOWEEN">DÍA DE BRUJAS</string>
+    <string name="HALLOWEEN">NOCHE DE BRUJAS</string>
     <string name="pack_info">Después de comprar este paquete de skins, sus máscaras exclusivas aparecerán en la parte superior de los menús de selección de skins..</string>
     <string name="EXCLUSIVE_skins_pets_hats_and_more_">¡EXCLUSIVO Skins, Mascotas, Sombreros y Más!</string>
     <string name="BUY_NOW_">¡COMPRAR AHORA!</string>


### PR DESCRIPTION
Edite "DIA DE BRUJAS" POR "NOCHE DE BRUJAS"
Ya que de las 2 formas son correctas pero investigando se conoce más como noche de brujas, además de eso "Día de brujas" está dicho de una forma más sencilla ya que en verdad es "Día de las brujas"   y "Noche de brujas" es dicho así correctamente.

ID: 13420431