### PR TITLE
Update strings.xml

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -24,7 +24,7 @@
     <string name="Loading___">"Wird geladen…"</string>
     <string name="Connecting___">"Verbinden…"</string>
 
-    <string name="Are_You_Sure_">"Bist du dir sicher?"</string>
+    <string name="Are_You_Sure_">"Sind Sie sicher?"</string>
     <string name="Yes">"Ja"</string>
     <string name="No">"Nein"</string>
     <string name="WAIT">"Bitte warten…"</string>


### PR DESCRIPTION
You call people below who are not 18 years old ´´Du´´ and it is pretty disrespectful calling  adults ´´Du´´ instead of ´´Sie´´.  In other games (even for children) are translated like that. I hope you understand my explanation and agree with my decision.

ID: 10072367
Discord: bek0o0