### PR TITLE
Update Idioma español (Latín America)

### DIFF
--- a/res/values-b+es+r419/strings.xml
+++ b/res/values-b+es+r419/strings.xml
@@ -125,7 +125,7 @@
     <string name="Achievement_Earned">"Logro conseguido"</string>
     <string name="REFRESH">"ACTUALIZAR"</string>
     <string name="DONE">"HECHO"</string>
-    <string name="Friend_Request_Sent">"Solicitud de amistad anviada"</string>
+    <string name="Friend_Request_Sent">"Solicitud de amistad enviada"</string>
     <string name="ERROR">"ERROR"</string>
     <string name="CONTINUE">"CONTINUAR"</string>
     <string name="Global_" formatted="false">"Global"</string>


### PR DESCRIPTION
En un string dice Anviada (Solicitud de amistad Anviada)  es incorrecto.

Y realmente es "Enviada" (Solicitud de amistad enviada) y es la forma correcta 

ID: 13420431