### PR TITLE
Inaccurate terminology

### DIFF
--- a/res/values-ar/strings.xml
+++ b/res/values-ar/strings.xml
@@ -178,7 +178,7 @@
 
     <string name="Perfection">"الإتقان"</string>
     <string name="Single_Handedly">"عمل فردي"</string>
-    <string name="Dodgey">"ملاحق الكلاب"</string>
+    <string name="Dodgey">"مراوغ"</string>
     <string name="Self_Contained">"اللاعب المتحفظ"</string>
     <string name="Survivalist">"المكافح"</string>
     <string name="Ultramassive">"العملاق"</string>


### PR DESCRIPTION

![Messenger_creation_CE1D3558-EB82-428D-A71E-96699056601F](https://github.com/user-attachments/assets/37d23870-1b20-4877-b30f-0cdbe073edb4)
Current translation: "ملاحق الكلاب"
Correct translation: "مراوغ" ,The word "ملاحق الكلاب" is inappropriate in the context and may be a leteral mistranslation.
Nebulous's ID : 22539568