### PR TITLE
Update various errors in Arabic language

### DIFF
--- a/res/values-ar/strings.xml
+++ b/res/values-ar/strings.xml
@@ -530,7 +530,7 @@
     <string name="DOMINATION">"السيطرة"</string>
     <string name="DOM_Domination">"السيطرة"</string>
     <string name="DOM_Hat_Trick">"سيطرة ثلاثية"</string>
-    <string name="Win_by_50_points_in_a_DOM_game_">"الفوز بفارق 50 نقطة في لعبة الهيمنة."</string>
+    <string name="Win_by_50_points_in_a_DOM_game_">"الفوز بفارق 50 نقطة في لعبة السيطرة."</string>
     <string name="Score_33_points_in_a_single_DOM_game_">"تسجيل 33 نقطة في لعبة سيطرة واحدة."</string>
     <string name="Win_a_Domination_Game">"الفوز في لعبة السيطرة"</string>
     <string name="Select_Team">"اختر فريق"</string>
@@ -577,7 +577,7 @@
     <string name="Language">"اللغة"</string>
     <string name="Control_Opacity_">" شفافية أزرار التحكم:"</string>
     <string name="You_dont_own_the_team_">" انت لا تمتلك الفريق:"</string>
-    <string name="User_has_already_been_invited_">" تم دعوة المستخدم ."</string>
+    <string name="User_has_already_been_invited_">" تمت دعوة المستخدم ."</string>
     <string name="Maximum_players_allowed_on_the_team_">"عدد اللاعبين الأقصى المسموح به في الفريق:"</string>
     <string name="Name_is_already_in_use_">"الاسم قيد الإستخدام بالفعل"</string>
     <string name="User_is_not_in_the_team_">"اللاعب ليس في الفريق."</string>
@@ -708,7 +708,7 @@
     <string name="Collect_10_000_notes_">"جمع 10،000 من رموز الموسيقى."</string>
     <string name="notes_">"رموز الموسيقى."</string>
     <string name="CLICK_CHEAT_DETECTED_">"اتم إكتشاف برامج غش!"</string>
-    <string name="Pumpkin_Hoarder">"مكدس اليقطين"</string>
+    <string name="Pumpkin_Hoarder">"جامع اليقطين"</string>
     <string name="Pumpkin_Mogul">"ملك تجميع اليقطين"</string>
     <string name="Leaf_Mogul">"ملك تجميع الأوراق"</string>
     <string name="Collect_5000_pumpkins_">"جمع 5000 من اليقطين."</string>
@@ -1106,7 +1106,7 @@
     <string name="ENEMY">عدو</string>
     <string name="ALLY">حليف</string>
     <string name="Rename">إعادة التسمية</string>
-    <string name="Set_friendly_name_">ضع اسما لصديقك.</string>
+    <string name="Set_friendly_name_">حدد اسما لصديقك.</string>
     <string name="Leave_blank_for_none_">اترك فراغا لعدم التغيير.</string>
     <string name="Vote_Kick">طرد اللاعب</string>
     <string name="FONT">نوع الخط</string>


### PR DESCRIPTION
1. Current translation "الفوز بفارق 50 نقطة في لعبة الهيمنة." , My preference would be "الفوز بفارق 50 نقطة في لعبة السيطرة.", where "السيطرة" is more consistent with the name of the game mode.
2. Current translation " تم دعوة المستخدم ." , Correction: " تمت دعوة المستخدم .", where “دعوة” fits better because it is a feminine verb.
3. Current translation "مكدس اليقطين" , “مكدس اليقطين” may sound strange in Standard Arabic, and perhaps could be replaced with clearer wording, such as “جامع اليقطين”.
4. Current translation "ضع اسما لصديقك." , Correct form "حدد اسماً لصديقك" (make sure “حدد” means “Set” instead of “ضع”).

These were my efforts to find some proposed solutions and make the game more accurate for players, I hope to get a Transalor Tag ID : 22539568
