### PR TITLE
Update Romanian Ro language

### DIFF
--- a/res/values-ro/strings.xml
+++ b/res/values-ro/strings.xml
@@ -269,7 +269,7 @@
     <string name="REMOVE_MEMBER">"ELIMINĂ MEMBRU"</string>
 
 
-    <string name="CREATE_CLAN">"CREAZĂ CLAN"</string>
+    <string name="CREATE_CLAN">"CREEAZĂ CLAN"</string>
     <string name="MEMBER">"MEMBRU"</string>
     <string name="ADMIN">"ADMIN"</string>
     <string name="LEADER">"LIDER"</string>


### PR DESCRIPTION
They forgot to add an "E" in a string .
ID 8839834