### PR TITLE
Update string portuguese br

### DIFF
--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -1457,7 +1457,7 @@ Se você não desejar fazer login, ainda poderá jogar no modo único jogador."
 
     <string-array name="clan_war_sizes">
         <item>"Dupla (2vs2)"</item>
-        <item>"Minúsculo (3vs3)"</item>
+        <item>"Trio (3vs3)"</item>
         <item>"Pequeno (5vs5)"</item>
         <item>"Normal (8vs8)"</item>
     </string-array>


### PR DESCRIPTION
I changed the string clan wars (3vs3) from "pequeno" to "trio" because the (2vs2) is "dupla", in english means "dual", and a (3vs3) In english means "trio".