### PR TITLE
Update Portuguese br language

### DIFF
--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -982,7 +982,7 @@ Se você notar um jogador quebrando as regras do jogo, denuncie a um Moderador.
     <string name="Kill_All_Bots">Mate Todos os Bots</string>
     <string name="Survive">Sobreviva</string>
     <string name="Mission_d_Complete">Missão %d Completa!</string>
-    <string name="Mission_d_Failed">Missão %d Falida!</string>
+    <string name="Mission_d_Failed">Missão %d Falhou!</string>
     <string name="Next_Mission">Próxima Missão</string>
     <string name="Objective">Objetivo</string>
     <string name="GAME">JOGO</string>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -892,7 +892,7 @@
     <string name="ROOM">SALA</string>
     <string name="EXPERIMENTAL">EXPERIMENTAL</string>
     <string name="members">Membros</string>
-    <string name="Delete_ALL_Messages_">Excluir TODAS as Mensagens!</string>
+    <string name="Delete_ALL_Messages_">Excluir Todas as Mensagens!</string>
     <string name="SAVE_PROFILE">SALVAR PERFIL</string>
     <string name="Move">Mover</string>
     <string name="New_Position">Nova Posição</string>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -816,7 +816,7 @@
     <string name="Next_Tournament">Próximo Torneio</string>
     <string name="Plasma_Won">Plasma Ganhado</string>
     <string name="Semi_Finals">Semi-Finais</string>
-    <string name="Quarter_Finals">Quartas de Finais</string>
+    <string name="Quarter_Finals">Quartas de Final</string>
     <string name="Competing">Competindo</string>
     <string name="Finals">Finais</string>
     <string name="Unregister">Cancelar Registro</string>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -1415,50 +1415,50 @@ Se você não desejar fazer login, ainda poderá jogar no modo único jogador."
     <string name="SUCCESS">BEM-SUCEDIDO</string>
 
     <string-array name="control_modes">
-        <item>"Normal"</item>
-        <item>"Relativo"</item>
-        <item>"Arrastar para Frente"</item>
-        <item>"Arrastar para Longe"</item>
-        <item>"Toque e Vá"</item>
-        <item>"Inclinar"</item>
+        <item>Normal</item>
+        <item>Relativo</item>
+        <item>Arrastar para Frente</item>
+        <item>Arrastar para Longe</item>
+        <item>Toque e Vá</item>
+        <item>Inclinar</item>
     </string-array>
 
     <string-array name="button_modes">
-        <item>"Esquerda"</item>
-        <item>"Direita"</item>
-        <item>"Direita+Esquerda"</item>
-        <item>"Pilha Esquerda"</item>
-        <item>"Pilha Direita"</item>
-        <item>"Personalizado"</item>
+        <item>Esquerda</item>
+        <item>Direita</item>
+        <item>Direita+Esquerda</item>
+        <item>Pilha Esquerda</item>
+        <item>Pilha Direita</item>
+        <item>Personalizado</item>
     </string-array>
 
     <string-array name="themes">
-        <item>"Estrelas (Escuro)"</item>
-        <item>"Grade (Escuro)"</item>
-        <item>"Grade (Branco)"</item>
-        <item>"Personalizado"</item>
-        <item>"Nenhum"</item>
+        <item>Estrelas (Escuro)"</item>
+        <item>Grade (Escuro)</item>
+        <item>Grade (Branco)</item>
+        <item>Personalizado</item>
+        <item>Nenhum</item>
     </string-array>
 
     <string-array name="difficulties">
-        <item>"Fácil"</item>
-        <item>"Médio"</item>
-        <item>"Difícil"</item>
-        <item>"IMPOSSÍVEL"</item>
+        <item>Fácil</item>
+        <item>Médio</item>
+        <item>Difícil</item>
+        <item>IMPOSSÍVEL</item>
     </string-array>
 
     <string-array name="sizes">
-        <item>"Minúsculo"</item>
-        <item>"Pequeno"</item>
-        <item>"Normal"</item>
-        <item>"Grande"</item>
-        <item>"ENORME"</item>
+        <item>Minúsculo</item>
+        <item>Pequeno</item>
+        <item>Normal</item>
+        <item>Grande</item>
+        <item>ENORME</item>
     </string-array>
 
     <string-array name="clan_war_sizes">
-        <item>"Dupla (2vs2)"</item>
-        <item>"Minúsculo (3vs3)"</item>
-        <item>"Pequeno (5vs5)"</item>
-        <item>"Normal (8vs8)"</item>
+        <item>Dupla (2vs2)</item>
+        <item>Minúsculo (3vs3)</item>
+        <item>Pequeno (5vs5)</item>
+        <item>Normal (8vs8)</item>
     </string-array>
 </resources>


### PR DESCRIPTION
     No XML usado para recursos de string em aplicativos Android, as aspas ao redor dos valores dentro das tags <item> não são necessárias e, de fato, podem causar problemas. As strings são definidas diretamente como texto dentro das tags <item>, e a inclusão de aspas pode ser interpretada literalmente, o que não é a intenção. 
    O padrão do XML para Android não exige aspas ao redor dos valores das strings, e seguir essa convenção ajuda a evitar erros de processamento e garante a compatibilidade com as ferramentas de desenvolvimento e execução.