### PR TITLE
Update Portuguese br language

### DIFF
--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -625,9 +625,9 @@
     <string name="Love_Nebulous_">"Ama o Nebulous?"</string>
     <string name="Please_support_Nebulous_by_rating_it_">"Por favor, apoie o Nebulous avaliando-o."</string>
     <string name="MAYHEM_MODE">"MODO MAYHEM"</string>
-    <string name="Times_Teleported_">"Vezes Teleportado:"</string>
-    <string name="Powerups_Used_">"Poderes Usado:"</string>
-    <string name="Power_Hungry">"Esfomeado de Poderes"</string>
+    <string name="Times_Teleported_">"Vezes Teletransportado:"</string>
+    <string name="Powerups_Used_">"Poderes Usados:"</string>
+    <string name="Power_Hungry">"Faminto de Poderes"</string>
     <string name="Over_9000">"Mais de 9.000"</string>
     <string name="Omnipresence">"Onipresença"</string>
 


### PR DESCRIPTION
"Vezes Teleportado:"
Sugestão: "Vezes Teletransportado:"
Justificativa: "Teletransportado" é o termo mais comumente usado em português para o conceito de "teleported". Embora "Teleportado" seja compreensível, "Teletransportado" é mais técnico e apropriado.

"Poderes Usado:"
Sugestão: "Poderes Usados:"
Justificativa: "Poderes" está no plural, então a palavra "Usado" deve concordar com o plural, tornando-se "Usados". Isso garante a concordância gramatical correta.

"Esfomeado de Poderes"
Sugestão: "Faminto por Poderes"
Justificativa: "Faminto por Poderes" é uma expressão mais natural e comum em português para transmitir o conceito de alguém que tem um desejo intenso por poder. "Esfomeado" é compreensível, mas "faminto" é mais usual e idiomático.