### PR TITLE
Update Portuguese br language

### DIFF
--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -814,12 +814,12 @@
     <string name="Registrants">Registrados</string>
     <string name="Round_Of">Rodada De</string>
     <string name="Next_Tournament">Próximo Torneio</string>
-    <string name="Plasma_Won">Plasma Ganhado</string>
+    <string name="Plasma_Won">Plasma Ganho</string>
     <string name="Semi_Finals">Semi-Finais</string>
     <string name="Quarter_Finals">Quartas de Finais</string>
     <string name="Competing">Competindo</string>
     <string name="Finals">Finais</string>
-    <string name="Unregister">Cancelar Registro</string>
+    <string name="Unregister">Cancelar Inscrição</string>
     <string name="Enter_My_Match">Entrar Na Minha Partida</string>
     <string name="Starts_In">Começa Em</string>
     <string name="Seconds">Segundos</string>


### PR DESCRIPTION
"Plasma Ganhado" – Pode ser mais claro como "Plasma Ganho" (usando o termo no particípio passado de forma mais natural).

Uma alternativa mais comun seria "Cancelar Inscrição"