### PR TITLE
Mejoras en traducción: joystick y botones

### DIFF
--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -4,8 +4,8 @@
     <string name="CLOSE">"CERRAR"</string>
     <string name="Stick_Size_">"Tamaño del Joystick:"</string>
     <string name="Stick_Margin_">"Margen del Joystick:"</string>
-    <string name="Button_Size_">"Tamaño del Boton:"</string>
-    <string name="Button_Margin_">"Margen del Boton:"</string>
+    <string name="Button_Size_">"Tamaño del Botón:"</string>
+    <string name="Button_Margin_">"Margen del Botón:"</string>
     <string name="Buttons_">"Botones:"</string>
     <string name="DEFAULTS">"POR DEFECTO"</string>
     <string name="WEEKLY">"SEMANAL"</string>


### PR DESCRIPTION
Hola, hice unas pequeñas mejoras en algunas frases del archivo en español para que suenen más claras y naturales dentro del juego:

- "Tamaño pad" > "Tamaño del joystick"
- "Ubicación pad" > "Margen del joystick"
- "Tamaño botones" > "Tamaño del botón"
- "Button margin" > "Margen del botón"

También corregí inconsistencias en el uso de mayúsculas en los textos en español para que coincidan con el estilo en inglés.

ID: 25032216

Gracias por revisar 🙂