### PR TITLE
Update to the valuee-b+es+r419 file.

### DIFF
--- a/res/values-b+es+r419/strings.xml
+++ b/res/values-b+es+r419/strings.xml
@@ -2,10 +2,10 @@
     <string name="Players">"Jugadores"</string>
     <string name="Control_">"Control:"</string>
     <string name="CLOSE">"CERRAR"</string>
-    <string name="Stick_Size_">"Tamaño Pad:"</string>
-    <string name="Stick_Margin_">"Ubicación Pad:"</string>
-    <string name="Button_Size_">"Tamaño Botones:"</string>
-    <string name="Button_Margin_">"Margen Botones:"</string>
+    <string name="Stick_Size_">"Tamaño del Pad:"</string>
+    <string name="Stick_Margin_">"Ubicación del Pad:"</string>
+    <string name="Button_Size_">"Tamaño de los Botones:"</string>
+    <string name="Button_Margin_">"Margen de los Botones:"</string>
     <string name="Buttons_">"Botones:"</string>
     <string name="DEFAULTS">"POR DEFECTO"</string>
     <string name="WEEKLY">"SEMANAL"</string>
@@ -27,19 +27,19 @@
     <string name="Yes">"Sí"</string>
     <string name="No">"No"</string>
     <string name="WAIT">"ESPERA…"</string>
-    <string name="Must_Specify_Name_">"Debes especificar un nombre "</string>
+    <string name="Must_Specify_Name_">"Debes especificar un nombre."</string>
 
-    <string name="Content_rating_of_the_app_may_change_when_finding_groups_">"El contenido de esta aplicación puede variar cuando se buscan grupos "</string>
+    <string name="Content_rating_of_the_app_may_change_when_finding_groups_">"El contenido de esta aplicación puede variar cuando se buscan grupos."</string>
 
     <string name="_Rank_">" Posición "</string>
     <string name="_Alias_">" Apodo "</string>
     <string name="_Score_">" Puntuación "</string>
     <string name="Score__">"Puntuación: "</string>
     <string name="Recombine_">"Juntarse: "</string>
-    <string name="WINNER_">"GANADOR: "</string>
+    <string name="WINNER_">"GANADOR:"</string>
     <string name="IDLE">"INACTIVO"</string>
-    <string name="Name_Invalid_">"Nombre Inválido "</string>
-    <string name="Name_Taken_">"Nombre en Uso "</string>
+    <string name="Name_Invalid_">"Nombre Inválido."</string>
+    <string name="Name_Taken_">"Nombre en Uso."</string>
     <string name="CONNECTED">"CONECTADO"</string>
     <string name="JOINING___">"UNIÉNDOSE…"</string>
     <string name="PLAYING">"JUGANDO"</string>
@@ -49,13 +49,13 @@
 
 
     <string name="Lobby_Name">"Nombre de la Sala"</string>
-    <string name="Not_found_">"No Encontrado "</string>
+    <string name="Not_found_">"No Encontrado."</string>
 
     <string name="Hidden">"Oculto"</string>
 
 
     <string name="SERVER">"SERVIDOR"</string>
-    <string name="Joining_game_in_">"Entrando al juego "</string>
+    <string name="Joining_game_in_">"Entrando al juego en:"</string>
     <string name="Game_Full">"Juego Lleno"</string>
     <string name="US_East">"Centroamérica"</string>
     <string name="US_West">"Norteamérica"</string>
@@ -66,7 +66,7 @@
     <string name="SINGLE_PLAYER">"UN JUGADOR"</string>
     <string name="Background_">"Fondo:"</string>
     <string name="Difficulty_">"Dificultad:"</string>
-    <string name="Delay_Disconnect">"Retraso en la desconexión"</string>
+    <string name="Delay_Disconnect">"Retrasar la desconexión"</string>
 
     <string name="Max_Players">"Jugadores Máximos"</string>
     <string name="Min_Players">"Jugadores Mínimos"</string>
@@ -95,13 +95,13 @@
     <string name="SIGN_OUT">"CERRAR SESIÓN"</string>
     <string name="ACHIEVEMENTS">"LOGROS"</string>
     <string name="STATISTICS">"ESTADÍSTICAS"</string>
-    <string name="XP_">"EXPERIENCIA:"</string>
+    <string name="XP_">"EXP:"</string>
 
     <string name="Information">"Información"</string>
-    <string name="To_use_this_skin_you_must_earn_the_achievement">"Para utilizar esta skin tienes que completar el logro"</string>
-    <string name="To_use_this_skin_you_must_reach_level">"Para utilizar esta skin tienes que alcanzar el nivel"</string>
+    <string name="To_use_this_skin_you_must_earn_the_achievement">"Para usar esta skin, tienes que completar el logro"</string>
+    <string name="To_use_this_skin_you_must_reach_level">"Para usar esta skin, tienes que alcanzar el nivel"</string>
 
-    <string name="Single_Player_Stats">"Estadísticas en modo "Un Jugador""</string>
+    <string name="Single_Player_Stats">"Estadísticas en modo \"Un Jugador\""</string>
 
     <string name="Level">"Nivel"</string>
     <string name="PAUSED">"EN PAUSA"</string>
@@ -129,16 +129,16 @@
     <string name="ERROR">"ERROR"</string>
     <string name="CONTINUE">"CONTINUAR"</string>
     <string name="Global_" formatted="false">"Global"</string>
-    <string name="FRIEND_CHAT">"CHAT DE AMIGO"</string>
-    <string name="LOBBY_NAME">"NOMBRE DE SALA"</string>
+    <string name="FRIEND_CHAT">"CHAT DE AMIGOS"</string>
+    <string name="LOBBY_NAME">"NOMBRE DE LA SALA"</string>
     <string name="NULL">"NULO"</string>
 
 
     <string name="ALL">"TODO"</string>
     <string name="FFA">"TCT"</string>
-    <string name="FFA_TIME">"TCT TIEMPO"</string>
+    <string name="FFA_TIME">"TCT CON TIEMPO"</string>
     <string name="TEAMS">"EQUIPOS"</string>
-    <string name="TEAMS_TIME">"EQUIPOS TIEMPO"</string>
+    <string name="TEAMS_TIME">"EQUIPOS CON TIEMPO"</string>
     <string name="CTF">"CLB"</string>
     <string name="SURVIVAL">"SUPERVIVENCIA"</string>
 
@@ -273,10 +273,10 @@
     <string name="MEMBER">"MIEMBRO"</string>
     <string name="ADMIN">"ADMIN"</string>
     <string name="LEADER">"LÍDER"</string>
-    <string name="ELDER">"VETERANO"</string>
+    <string name="ELDER">"ANCIANO"</string>
 
 
-    <string name="Not_in_a_clan_">"Sin clan "</string>
+    <string name="Not_in_a_clan_">"No estás en un clan."</string>
 
 
     <string name="CLAN">"CLAN"</string>
@@ -286,64 +286,64 @@
     <string name="Show_Clan_Names">"Mostrar Clanes"</string>
     <string name="Show_Levels">"Mostrar Niveles"</string>
     <string name="SET_MOTD">"ESTABLECER DESCRIPCIÓN"</string>
-    <string name="No_such_user_found_">"No se encontró dicho usuario "</string>
-    <string name="No_open_public_clans_exist_">"No existen Clanes públicos abiertos "</string>
-    <string name="You_aren_t_invited_to_that_clan_">"No te han invitado a este Clan "</string>
-    <string name="No_such_clan_exists_">"El Clan no existe "</string>
-    <string name="That_clan_is_full_">"El Clan está lleno "</string>
-    <string name="Other_user_is_not_a_member_of_your_clan_">"Otro usuario no es un miembro de tu Clan "</string>
-    <string name="_You_can_t_be_your_own_friend_">"No puedes ser tu propio amigo "</string>
-    <string name="A_clan_with_that_name_already_exists_">"Ya existe un Clan con ese nombre "</string>
+    <string name="No_such_user_found_">"No se encontró dicho usuario."</string>
+    <string name="No_open_public_clans_exist_">"No existen clanes públicos abiertos."</string>
+    <string name="You_aren_t_invited_to_that_clan_">"No te han invitado a este clan."</string>
+    <string name="No_such_clan_exists_">"El clan no existe."</string>
+    <string name="That_clan_is_full_">"El clan está lleno."</string>
+    <string name="Other_user_is_not_a_member_of_your_clan_">"Otro usuario no es un miembro de tu clan."</string>
+    <string name="_You_can_t_be_your_own_friend_">"No puedes ser tu propio amigo."</string>
+    <string name="A_clan_with_that_name_already_exists_">"Ya existe un clan con ese nombre."</string>
     <string name="Duration_">"Duración:"</string>
 
-    <string name="FFA_Time_Domination">"Dominio en TCT Tiempo"</string>
-    <string name="Teams_Time_Domination">"Dominio en Equipos Tiempo"</string>
+    <string name="FFA_Time_Domination">"Dominio en TCT con Tiempo"</string>
+    <string name="Teams_Time_Domination">"Dominio en Equipos con Tiempo"</string>
     <string name="CTF_Domination">"Dominio en CLB"</string>
     <string name="CTF_Hat_Trick">"Triplete en CLB"</string>
     <string name="Survival_Domination">"Dominio en Supervivencia"</string>
     <string name="I_Will_Survive">"Sobreviviré"</string>
     <string name="Soccer_Domination">"Dominio en Fútbol"</string>
     <string name="Soccer_Hat_Trick">"Triplete en Fútbol"</string>
-    <string name="Win_by_2_500_points_in_an_FFA_Time_game_">"Gana por 2,500 puntos en TCT Tiempo"</string>
-    <string name="Win_by_7_500_points_in_an_Teams_Time_game_">"Gana por 7,500 puntos en Equipos Tiempo"</string>
-    <string name="Win_by_3_points_in_a_CTF_game_">"Gana por 3 puntos en CLB"</string>
-    <string name="Score_3_points_in_a_single_CTF_game_">"Haz 3 puntos en CLB en modo Un jugador"</string>
-    <string name="Win_by_2_500_points_in_a_Survival_game_">"Gana con 2,500 puntos en Supervivencia"</string>
-    <string name="Survive_but_do_not_win_a_survival_game_">"Sobrevive en Supervivencia sin ganar"</string>
-    <string name="Win_by_8_points_in_a_Soccer_game_">"Gana por 8 goles en un partido de Fútbol"</string>
-    <string name="Score_3_goals_in_a_single_Soccer_game_">"Marca 3 goles en un solo partido de Fútbol"</string>
+    <string name="Win_by_2_500_points_in_an_FFA_Time_game_">"Gana por 2,500 puntos en TCT con Tiempo."</string>
+    <string name="Win_by_7_500_points_in_an_Teams_Time_game_">"Gana por 7,500 puntos en Equipos con Tiempo."</string>
+    <string name="Win_by_3_points_in_a_CTF_game_">"Gana por 3 puntos en CLB."</string>
+    <string name="Score_3_points_in_a_single_CTF_game_">"Haz 3 puntos en CLB en modo Un jugador."</string>
+    <string name="Win_by_2_500_points_in_a_Survival_game_">"Gana con 2,500 puntos en Supervivencia."</string>
+    <string name="Survive_but_do_not_win_a_survival_game_">"Sobrevive en Supervivencia sin ganar."</string>
+    <string name="Win_by_8_points_in_a_Soccer_game_">"Gana por 8 goles en un partido de Fútbol."</string>
+    <string name="Score_3_goals_in_a_single_Soccer_game_">"Marca 3 goles en un solo partido de Fútbol."</string>
     <string name="Total_Domination">"Dominio total"</string>
-    <string name="Win_500_games_of_any_type_">"Gana 500 juegos de cualquier tipo"</string>
+    <string name="Win_500_games_of_any_type_">"Gana 500 juegos de cualquier tipo."</string>
     <string name="Translations">"Traducciones"</string>
     <string name="Developers">"Desarrolladores"</string>
     <string name="Special_Thanks">"Agradecimientos especiales"</string>
-    <string name="Many_Thanks_To_Every_Nebulous_Fan">"¡Muchas gracias a todos los fans de Nebulous!"</string>
+    <string name="Many_Thanks_To_Every_Nebulous_Fan">"Muchas gracias a todos los fans de Nebulous"</string>
     <string name="Color_Blind">"Modo daltónico"</string>
     <string name="Daily_Quest_Complete_">"¡Misión diaria completada!"</string>
     <string name="COPY_ID">"COPIAR ID"</string>
-    <string name="My_Account_ID">"Mi ID"</string>
+    <string name="My_Account_ID">"ID de Mi Cuenta"</string>
 
 
     <string name="COMPLETE">"COMPLETA"</string>
     <string name="INCOMPLETE">"INCOMPLETA"</string>
-    <string name="Win_a_FFA_Time_Game">"Gana una partida de TCT Tiempo"</string>
+    <string name="Win_a_FFA_Time_Game">"Gana una partida de TCT con Tiempo"</string>
     <string name="Win_a_CTF_Game">"Gana una partida de CLB"</string>
     <string name="Win_a_Soccer_Game">"Gana un partido de Fútbol"</string>
     <string name="Win_a_Survival_Game">"Gana una partida de Supervivencia"</string>
-    <string name="Win_a_Teams_Time_Game">"Gana una partida de Equipos Tiempo"</string>
+    <string name="Win_a_Teams_Time_Game">"Gana una partida de Equipos con Tiempo"</string>
     <string name="Reach_a_score_of_">"Alcanza una puntuación de "</string>
     <string name="_in_a_FFA_Game">" en una partida de TCT"</string>
     <string name="_in_a_Teams_Game">" en un partida de Equipos"</string>
-    <string name="_dots">" Puntos"</string>
-    <string name="_player_blobs">" Blobs del jugador"</string>
+    <string name="_dots">" puntos"</string>
+    <string name="_player_blobs">" blobs del jugador"</string>
     <string name="Absorb_">"Absorber "</string>
     <string name="Collect_">"Recoger "</string>
 
     <string name="FFA_CLASSIC">"TCT CLÁSICO"</string>
 
 
-    <string name="pumpkins_">"calabazas "</string>
-    <string name="To_use_this_skin_you_must_collect">"Para utilizar esta skin tienes que recoger"</string>
+    <string name="pumpkins_">"calabazas."</string>
+    <string name="To_use_this_skin_you_must_collect">"Para usar esta skin, tienes que recoger"</string>
     <string name="Australia">"Australia"</string>
     <string name="Pumpkin_Collector">"Coleccionista de Calabazas"</string>
     <string name="Collect_1000_pumpkins_">"Recoge 1,000 calabazas."</string>
@@ -376,7 +376,7 @@
     <string name="W_D_L">"G-E-P"</string>
     <string name="MATCH_START">"COMIENZA LA PARTIDA EN"</string>
     <string name="Clan_Warrior">"Guerrero del Clan"</string>
-    <string name="Win_a_Clan_War">"Gana una guerra de Clanes"</string>
+    <string name="Win_a_Clan_War">"Gana una Guerra de Clanes"</string>
     <string name="Global">"Global"</string>
     <string name="Spectating">"Observando"</string>
 
@@ -391,10 +391,10 @@
     <string name="The_next_season_begins">"La próxima temporada comienza:"</string>
 
     <string name="Current">"Actual"</string>
-    <string name="leaves_">"hojas "</string>
+    <string name="leaves_">"hojas."</string>
     <string name="Leaf_Collector">"Coleccionista de Hojas"</string>
     <string name="Collect_1000_leaves_">"Recoge 1,000 hojas."</string>
-    <string name="XP_Boost">"Acelerar EXP"</string>
+    <string name="XP_Boost">"Impulso de EXP"</string>
     <string name="Double">"Doble"</string>
     <string name="Hour">"Hora"</string>
     <string name="Hours">"Horas"</string>
@@ -423,30 +423,30 @@
     <string name="Purchasing">"Comprando"</string>
 
     <string name="Purchase_Successful_">"¡Compra realizada con éxito!"</string>
-    <string name="You_may_need_to_reconnect_to_use_the_purchase_">"Puede que tengas que reconectarte para utilizar lo comprado"</string>
+    <string name="You_may_need_to_reconnect_to_use_the_purchase_">"Es posible que necesites reconectarse para usar lo comprado"</string>
     <string name="Confirm_Purchase">"Confirmar compra"</string>
     <string name="x3_XP_24_hours">"EXP 3x 24 horas"</string>
     <string name="x3_XP_1_Hour">"EXP 3x 1 hora"</string>
     <string name="x2_XP_24_Hour">"EXP 2x 24 horas"</string>
     <string name="x2_XP_1_Hour">"EXP 2x 1 hora"</string>
     <string name="Cost_">"Precio:"</string>
-    <string name="You_cannot_purchase_this_right_now_">"No puedes comprar esto en este momento "</string>
+    <string name="You_cannot_purchase_this_right_now_">"No puedes comprar esto en este momento."</string>
 
 
     <string name="Loading_Purchases___">"Cargando compras…"</string>
     <string name="In_App_Purchases">"Compras en la aplicación"</string>
-    <string name="Cannot_apply_new_XP_boost_until_current_boost_expires_">"No se puede aplicar otro acelerador de EXP hasta que el acelerador actual termine."</string>
+    <string name="Cannot_apply_new_XP_boost_until_current_boost_expires_">"No se puede aplicar otro impulso de EXP hasta que expire el actual."</string>
     <string name="This_purchase_has_already_been_redeemed_">"Esta compra ya ha sido canjeada."</string>
 
     <string name="You_cannot_remove_yourself__Leave_clan_instead_">"No te puedes expulsar a ti mismo. En su lugar, solamente abandona el clan "</string>
 
 
-    <string name="until">"hasta"</string>
+    <string name="until">"Hasta"</string>
     <string name="New_Message_">"¡Nuevo Mensaje!"</string>
     <string name="Seasonal">"Estacional"</string>
 
 
-    <string name="Temporarily_Disabled_">"Desactivado temporalmente "</string>
+    <string name="Temporarily_Disabled_">"Desactivado temporalmente."</string>
     <string name="BIGGEST">"EL MÁS GRANDE"</string>
 
 
@@ -457,7 +457,7 @@
     <string name="Player_Name">"Nombre del Jugador"</string>
 
     <string name="Daily_Reward">"Recompensa Diaria"</string>
-    <string name="Reset">"Reiniciar"</string>
+    <string name="Reset">"Restablecer"</string>
     <string name="Plasma">"Plasma"</string>
     <string name="Plasma_Mogul">"Magnate de Plasma"</string>
     <string name="Plasma_Collector">"Coleccionista de Plasma"</string>
@@ -471,20 +471,20 @@
     <string name="ENTER">"ENTRAR"</string>
     <string name="_1v1">" 1vs1"</string>
     <string name="Practice">"Practicar"</string>
-    <string name="ArenaDescription">Solo obtienes una vida. El ganador recibirá %s plasma. Si haces trampa para conseguir "Puntos Gratis" serás baneado.</string>
+    <string name="ArenaDescription">Solo obtienes una vida. El ganador recibirá %s plasma. Si haces trampa para conseguir \"Puntos Gratis\" serás baneado.</string>
     <string name="Contestant">"Concursante"</string>
     <string name="Duelist">"Duelista"</string>
     <string name="Gladiator">"Gladiador"</string>
     <string name="Challenger">"Contrincante"</string>
-    <string name="Win_1_1v1_Arenas_">"Gana una Arena 1vs1 "</string>
+    <string name="Win_1_1v1_Arenas_">"Gana una Arena 1vs1."</string>
     <string name="Win_10_Arenas_">"Gana 10 Arenas."</string>
     <string name="Win_100_Arenas_">"Gana 100 Arenas."</string>
     <string name="Win_1000_Arenas">"Gana 1,000 Arenas."</string>
 
 
-    <string name="Already_in_arena_">"En la Arena "</string>
-    <string name="Already_in_queue_">"En la cola "</string>
-    <string name="Invalid_Account_ID_">"ID de cuenta inválida "</string>
+    <string name="Already_in_arena_">"Ya estás en la Arena."</string>
+    <string name="Already_in_queue_">"Ya estás en la cola "</string>
+    <string name="Invalid_Account_ID_">"ID de cuenta inválida."</string>
 
     <string name="Validating">"Validando"</string>
 
@@ -504,7 +504,7 @@
     <string name="Clan_General">"General del Clan"</string>
     <string name="Clan_Wars_Won_">"Guerras de Clanes ganadas:"</string>
     <string name="Arenas_Won_">"Arenas Ganadas:"</string>
-    <string name="Arena_Mode">"Modo Arena"</string>
+    <string name="Arena_Mode">"Modo de Arena"</string>
     <string name="Connection_Lost">"Conexión Perdida"</string>
 
     <string name="Present_Hoarder">"Acaparador de Regalos"</string>
@@ -525,14 +525,14 @@
     <string name="Start_Clan_War">"Empezar Guerra de Clanes</string>
     <string name="Min_Level">"Nivel Mínimo"</string>
     <string name="SAVE">"GUARDAR"</string>
-    <string name="Player_does_not_meet_the_minimum_level_requirement_to_join_the_clan_">"Este jugador no cumple con el requisito mínimo de nvel para unirse a este clan:"</string>
+    <string name="Player_does_not_meet_the_minimum_level_requirement_to_join_the_clan_">"Este jugador no cumple con el requisito mínimo de nivel para unirse a este clan:"</string>
     <string name="Insufficient_Permission">"Permiso Insuficiente"</string>
     <string name="DOMINATION">"DOMINACIÓN"</string>
     <string name="DOM_Domination">"Dominar en Dominación"</string>
     <string name="DOM_Hat_Trick">"Triplete en Dominación"</string>
-    <string name="Win_by_50_points_in_a_DOM_game_">"Gana por 50 puntos en una partida de Dominación "</string>
-    <string name="Score_33_points_in_a_single_DOM_game_">"Consigue 33 puntos en una sola partida de Dominación "</string>
-    <string name="Win_a_Domination_Game">"Gana una partida de Dominación "</string>
+    <string name="Win_by_50_points_in_a_DOM_game_">"Gana por 50 puntos en una partida de Dominación."</string>
+    <string name="Score_33_points_in_a_single_DOM_game_">"Consigue 33 puntos en una sola partida de Dominación."</string>
+    <string name="Win_a_Domination_Game">"Gana una partida de Dominación."</string>
     <string name="Select_Team">"Seleccionar Equipo"</string>
     <string name="MANAGE_TEAMS">"GESTIONAR EQUIPOS"</string>
     <string name="CLAN_INVITE">"INVITAR AL CLAN"</string>
@@ -545,9 +545,9 @@
     <string name="Team">"Equipo"</string>
     <string name="Specify_Account_ID">"Escribe la ID de tu Amigo"</string>
     <string name="Team_Created_">"¡Equipo Creado!"</string>
-    <string name="Team_Arena">"Arena Equipos"</string>
+    <string name="Team_Arena">"Arena Por Equipos"</string>
     <string name="No_Teams">"No hay Equipos"</string>
-    <string name="team_arena_info">"Una vez crees un equipo, puedes invitar y eliminar miembros de forma gratuita. También podrás jugar partidas por equipos en la arena. ¡No se puede cambiar el nombre del equipo una vez creado!"</string>
+    <string name="team_arena_info">"Una vez crees un equipo, puedes invitar y eliminar miembros libremente. También podrás jugar partidas por equipos en la arena. ¡No se puede cambiar el nombre del equipo una vez creado!"</string>
 
 
     <string name="Invited">"Invitado"</string>
@@ -556,54 +556,54 @@
     <string name="Reported">"Denunciado"</string>
     <string name="Threats">"Amenazas"</string>
     <string name="Spam">"Correo no deseado"</string>
-    <string name="Other">"Otros motivos"</string>
+    <string name="Other">"Otro"</string>
     <string name="Leave_Team">"Abandonar Equipo"</string>
 
     <string name="Remove_Player">"Eliminar Jugador"</string>
     <string name="Reject_Invitation">"Rechazar Invitacion"</string>
     <string name="Leave_Game">"Abandonar el Juego"</string>
     <string name="Remove_Friend">"Eliminar Amigo"</string>
-    <string name="Remove_Clan_Member">"Expulsar miembro del Clan"</string>
+    <string name="Remove_Clan_Member">"Eliminar Miembro del Clan"</string>
     <string name="Flag_lobby_as_inappropriate">"Marcar sala como inadecuada"</string>
     <string name="Promote_Clan_Member">"Ascender Miembro"</string>
-    <string name="Leave_Clan">"Dejar el Clan"</string>
+    <string name="Leave_Clan">"Abandonar el Clan"</string>
     <string name="Candy_Hoarder">"Acaparador de Caramelos"</string>
     <string name="Candy_Collector">"Coleccionista de Caramelos"</string>
     <string name="Candy_Mogul">"Magnate de Caramelos"</string>
     <string name="Collect_1_000_candies_">"Recoge 1,000 Caramelos."</string>
     <string name="Collect_5_000_candies_">"Recoge 5,000 Caramelos."</string>
     <string name="Collect_10_000_candies_">"Recoge 10,000 Caramelos."</string>
-    <string name="Candies_">"Caramelos "</string>
+    <string name="candies_">"Caramelos."</string>
     <string name="Language">"Idioma"</string>
-    <string name="Control_Opacity_">"Control de opacidad:"</string>
+    <string name="Control_Opacity_">"Opacidad de los controles:"</string>
     <string name="You_dont_own_the_team_">"No eres el dueño del equipo:"</string>
-    <string name="User_has_already_been_invited_">"El usuario ya ha sido invitado "</string>
-    <string name="Maximum_players_allowed_on_the_team_">"Máximos jugadores permitidos en el equipo:"</string>
-    <string name="Name_is_already_in_use_">"Este nombre ya está en uso "</string>
-    <string name="User_is_not_in_the_team_">"Este usuario no está en el equipo "</string>
-    <string name="You_are_not_invited_to_team_">"No has sido invitado al equipo "</string>
-    <string name="Team_does_not_exist_">"El equipo no existe "</string>
-    <string name="Please_wait_a_minute_before_sending_another_report_">"Por favor, espera un minuto antes de enviar otra denuncia "</string>
+    <string name="User_has_already_been_invited_">"El usuario ya ha sido invitado."</string>
+    <string name="Maximum_players_allowed_on_the_team_">"Máximo de jugadores permitidos en el equipo:"</string>
+    <string name="Name_is_already_in_use_">"Este nombre ya está en uso."</string>
+    <string name="User_is_not_in_the_team_">"Este usuario no está en el equipo."</string>
+    <string name="You_are_not_invited_to_team_">"No has sido invitado al equipo:"</string>
+    <string name="Team_does_not_exist_">"El equipo no existe:"</string>
+    <string name="Please_wait_a_minute_before_sending_another_report_">"Por favor, espera un minuto antes de enviar otra denuncia."</string>
     <string name="Collect_1_000_beads_">"Recoge 1,000 perlas."</string>
     <string name="Collect_5_000_beads_">"Recoge 5,000 perlas."</string>
     <string name="Collect_10_000_beads_">"Recoge 10,000 perlas."</string>
     <string name="Bead_Collector">"Coleccionista de perlas"</string>
     <string name="Bead_Hoarder">"Acaparador de perlas"</string>
     <string name="Bead_Mogul">"Magnate de perlas"</string>
-    <string name="beads_">"perlas "</string>
+    <string name="beads_">"perlas."</string>
 
     <string name="Rejoin_Game">"Volver a unirse a la partida"</string>
     <string name="PRIZES">"PREMIOS"</string>
 
     <string name="Enable_Custom_Skin">"Habilitar skin personalizada"</string>
-    <string name="Use_Custom_Skin">"Skin\npersonalizada"</string>
-    <string name="custom_skin_description">"Esta característica te permite utilizar la imagen que quieras como su skin. Esto sólo cambiará la skin que ves. Otras personas no verán tu aspecto personalizado."</string>
+    <string name="Use_Custom_Skin">"Skin\nPersonalizada"</string>
+    <string name="custom_skin_description">"Esta característica te permite utilizar la imagen que quieras como su skin. Esto sólo cambiará la skin que ves. Otras personas no verán tu skin personalizada a menos que subas."</string>
     <string name="CUSTOM_SKIN">"SKIN PERSONALIZADA"</string>
 
     <string name="Facebook_Profile">"Perfil de Facebook"</string>
     <string name="You_must_be_signed_in_to_Facebook_">"Debes iniciar sesión en Facebook."</string>
     <string name="copy_details">"Copiar Detalles"</string>
-    <string name="copied_error_details_to_clipboard">"Detalles del error copiados al portapapeles"</string>
+    <string name="copied_error_details_to_clipboard">"Detalles del error copiados al portapapeles."</string>
 
     <string name="No_file_browser_installed_">"¡No hay ningún explorador de archivos instalado!"</string>
     <string name="Choose_File">"Elegir Archivo"</string>
@@ -612,7 +612,7 @@
 
 
     <string name="MAYHEM">"CAOS"</string>
-    <string name="eggs_">"huevos "</string>
+    <string name="eggs_">"huevos."</string>
     <string name="Egg_Collector">"Coleccionista de huevos"</string>
     <string name="Egg_Hoarder">"Acaparador de huevos"</string>
     <string name="Egg_Mogul">"Magnate de huevos"</string>
@@ -624,7 +624,7 @@
 
 
     <string name="Love_Nebulous_">"¿Te gusta el Nebulous?"</string>
-    <string name="Please_support_Nebulous_by_rating_it_">"Por favor, apoya a Nebulous puntuándolo "</string>
+    <string name="Please_support_Nebulous_by_rating_it_">"Por favor, apoya a Nebulous puntuándolo."</string>
     <string name="MAYHEM_MODE">"MODO CAOS"</string>
     <string name="Times_Teleported_">"Veces Teletransportado:"</string>
     <string name="Powerups_Used_">"Poderes Usados:"</string>
@@ -640,22 +640,22 @@
     <string name="Account_In_Use_">"La cuenta está en uso"</string>
     <string name="Cannot_Join_Arena_">"No te puedes unir a la Arena "</string>
     <string name="Signing_out_will_disconnect_you_from_the_current_game">"¡Si sales te desconectarás de la partida actual!"</string>
-    <string name="Raindrops_">"Gotas de lluvia "</string>
+    <string name="raindrops_">"Gotas de Lluvia."</string>
     <string name="Raindrop_Collector">"Coleccionista de gotas de lluvia"</string>
     <string name="Raindrop_Hoarder">"Acaparador de gotas de lluvia"</string>
     <string name="Raindrop_Mogul">"Magnate de gotas de lluvia"</string>
     <string name="Collect_1_000_raindrops_">"Recoge 1,000 gotas de lluvia."</string>
     <string name="Collect_5_000_raindrops_">"Recoge 5,000 gotas de lluvia."</string>
     <string name="Collect_10_000_raindrops_">"Recoge 10,000 gotas de lluvia."</string>
-    <string name="Copy_Message">"Copiar mensaje"</string>
-    <string name="Copied_to_clipboard_">"Copiado al portapapeles "</string>
+    <string name="Copy_Message">"Copiar Mensaje"</string>
+    <string name="Copied_to_clipboard_">"Copiado al portapapeles."</string>
     <string name="COPY_NAME">"COPIAR NOMBRE"</string>
     <string name="Challenge_Sent">"Reto Enviado"</string>
-    <string name="_1v1_Challenge_">" ¡Reto 1vs1! "</string>
-    <string name="__has_challenged_you_to_a_1v1_match_">"%s te ha retado a un 1vs1!"</string>
-    <string name="Challenge_Expired">"Reto fuera de plazo"</string>
+    <string name="_1v1_Challenge_">" Reto 1vs1 "</string>
+    <string name="__has_challenged_you_to_a_1v1_match_">"¡%s te ha retado a un 1vs1!"</string>
+    <string name="Challenge_Expired">"Reto Expirado"</string>
     <string name="Enable_Challenges">"Habilitar Retos"</string>
-    <string name="Wait_for_the_current_challenge_to_expire_">"Espera a que el reto actual termine"</string>
+    <string name="Wait_for_the_current_challenge_to_expire_">"Espera a que expire el reto actual"</string>
     <string name="CHALLENGE_OPTIONS">"OPCIONES DE RETO"</string>
     <string name="Accept">"Aceptar"</string>
     <string name="Decline">"Rechazar"</string>
@@ -667,15 +667,15 @@
     <string name="Collect_1_000_nebulas_">"Recoge 1,000 Nebulosas."</string>
     <string name="Collect_5_000_nebulas_">"Recoge 5,000 Nebulosas."</string>
     <string name="Collect_10_000_nebulas_">"Recoge 10,000 Nebulosas."</string>
-    <string name="nebulas_">"Nebulosas "</string>
-    <string name="Incompatible_versions_">"Versiones incompatibles "</string>
+    <string name="nebulas_">"nebulosas."</string>
+    <string name="Incompatible_versions_">"Versiones incompatibles."</string>
     <string name="Update_Available_">"¡Actualización Disponible!"</string>
     <string name="VIEW_INVITES">"VER INVITACIONES"</string>
     <string name="CLAN_INVITES">"INVITACIONES A CLANES"</string>
     <string name="Cancel_Invitation">"Cancelar la invitación"</string>
     <string name="DOWNLOAD">"DESCARGAR"</string>
     <string name="REJECT_ALL_FRIEND_INVITATIONS_">"Rechazar todas las invitaciones de amigos"</string>
-    <string name="Suns_">"Soles "</string>
+    <string name="suns_">"soles."</string>
     <string name="Sun_Collector">"Coleccionista de Soles"</string>
     <string name="Sun_Hoarder">"Acaparador de Soles"</string>
     <string name="Sun_Mogul">"Magnate de Soles"</string>
@@ -684,7 +684,7 @@
     <string name="Collect_10_000_suns_">"Recoge 10,000 soles."</string>
     <string name="Reward_Videos_">"¡Vídeos de recompensa!"</string>
     <string name="Free_Plasma_">"¡Plasma gratis!"</string>
-    <string name="moons_">"lunas "</string>
+    <string name="moons_">"lunas."</string>
     <string name="Moon_Collector">"Coleccionista de Lunas"</string>
     <string name="Moon_Hoarder">"Atesorador de Lunas"</string>
     <string name="Moon_Mogul">"Magnate de Lunas"</string>
@@ -693,12 +693,12 @@
     <string name="Collect_10_000_moons_">"Recoge 10,000 lunas."</string>
     <string name="BLUETOOTH">"BLUETOOTH"</string>
     <string name="HOST">"ANFITRIÓN"</string>
-    <string name="This_device_does_not_support_bluetooth_">"Este dispositivo no es compatible con bluetooth "</string>
-    <string name="member_permissions">"permisos de miembros"</string>
-    <string name="edit">"editar"</string>
-    <string name="start_clan_war">"iniciar guerra de clanes"</string>
-    <string name="join_clan_war">"unirse a guerras de clanes"</string>
-    <string name="none">"ninguno"</string>
+    <string name="This_device_does_not_support_bluetooth_">"Este dispositivo no es compatible con bluetooth."</string>
+    <string name="member_permissions">"Permisos de Miembros"</string>
+    <string name="edit">"EDITAR"</string>
+    <string name="start_clan_war">"Iniciar Guerra de Clanes"</string>
+    <string name="join_clan_war">"Unirse a Guerras de Clanes"</string>
+    <string name="none">"Ninguno"</string>
     <string name="INVALID_TOKEN">"TOKEN INVÁLIDO"</string>
     <string name="banned_until">"Baneado hasta"</string>
     <string name="Note_Collector">"Coleccionista de Notas"</string>
@@ -707,8 +707,8 @@
     <string name="Collect_1_000_notes_">"Recoge 1,000 notas."</string>
     <string name="Collect_5_000_notes_">"Recoge 5,000 notas."</string>
     <string name="Collect_10_000_notes_">"Recoge 10,000 notas."</string>
-    <string name="notes_">"notas "</string>
-    <string name="CLICK_CHEAT_DETECTED_">"¡AUTOCLICK DETECTADO!"</string>
+    <string name="notes_">"notas."</string>
+    <string name="CLICK_CHEAT_DETECTED_">"¡HACK DE CLICK DETECTADO!"</string>
     <string name="Pumpkin_Hoarder">"Acaparador de Calabazas"</string>
     <string name="Pumpkin_Mogul">"Magnate de Calabazas"</string>
     <string name="Leaf_Mogul">"Magnate de Hojas"</string>
@@ -718,7 +718,7 @@
     <string name="Eject">"Expulsar"</string>
     <string name="Eject_Skin">"Skin de masa expulsada"</string>
     <string name="Double_Plasma__">"¡¡Doble plasma!!"</string>
-    <string name="Ends">"Acaba"</string>
+    <string name="Ends">"Acaba en"</string>
     <string name="Select_Clan_Member">"Seleccionar miembros del clan"</string>
     <string name="Inappropriate_Skin">"Skin inapropiada"</string>
     <string name="Approved">"Aprobada"</string>
@@ -728,7 +728,7 @@
 
     <string name="contribution_warning">"¿Estás seguro de que quieres donar ese plasma? Las donaciones no serán devueltas."</string>
     <string name="Upload">"Subir"</string>
-    <string name="upload_warning">"¿Estás seguro de que deseas subir esta skin? Otros jugadores serán capaces de ver esa skin. Puede tardar hasta 1 semana en ser revisada. ¡Las skins inapropiadas serán rechazadas y el plasma no será devuelto!"</string>
+    <string name="upload_warning">"¿Estás seguro de que deseas subir esta skin? Otros jugadores serán capaces de ver esa skin. Puede tardar hasta 1 semana en ser revisada. ¡Las skins inapropiadas podrán ser reembolsadas o rechazadas dependiendo de la gravedad!"</string>
 
     <string name="In_Review">"En Revisión"</string>
     <string name="Account_Uploads">"Skins de la Cuenta"</string>
@@ -745,10 +745,10 @@
     <string name="List_Count_">"Lista de Recuento:"</string>
     <string name="Download_Skins">"Descargar skins"</string>
     <string name="ARENA_HISTORY">"HISTORIAL DE ARENA"</string>
-    <string name="WIN">"GANADA"</string>
-    <string name="LOSS">"PERDIDA"</string>
-    <string name="Other_players_can_not_see_your_skin_">"Los demás jugadores no pueden ver su skin "</string>
-    <string name="Other_players_can_see_your_skin_">"Los demás jugadores pueden ver su skin "</string>
+    <string name="WIN">"VICTORIA"</string>
+    <string name="LOSS">"DERROTA"</string>
+    <string name="Other_players_can_not_see_your_skin_">"Los demás jugadores no podrán ver su skin."</string>
+    <string name="Other_players_can_see_your_skin_">"Los demás jugadores podrán ver su skin."</string>
     <string name="LEGEND">"LEYENDA"</string>
     <string name="UPLOAD_PREVIEW">"PREVISUALIZACIÓN"</string>
     <string name="Win_10000_Arenas">"Gana 10,000 Arenas"</string>
@@ -772,25 +772,25 @@
     <string name="Subject">"Asunto:"</string>
     <string name="SEND">"ENVIAR"</string>
     <string name="To">"Para:"</string>
-    <string name="RESET">"RESETEAR"</string>
+    <string name="RESET">"RESTABLECER"</string>
     <string name="Message_Sent_">"¡Mensaje enviado!"</string>
     <string name="From">"De"</string>
     <string name="Sent">"Enviado"</string>
     <string name="REPLY">"RESPONDER"</string>
-    <string name="Delete_Message">"Borrar mensaje"</string>
+    <string name="Delete_Message">"Eliminar Mensaje"</string>
     <string name="BLOCK">"BLOQUEAR"</string>
-    <string name="DELETE">"BORRAR"</string>
-    <string name="Note__You_can_unblock_someone_by_sending_them_a_friend_request_">"Nota: Se puede desbloquear a alguien enviándole una solicitud de amistad "</string>
-    <string name="Select_Friend">"Elije un Amigo"</string>
-    <string name="Failed_to_send_mail_">"No se pudo enviar el correo "</string>
+    <string name="DELETE">"Eliminar"</string>
+    <string name="Note__You_can_unblock_someone_by_sending_them_a_friend_request_">"Nota: Se puede desbloquear a alguien enviándole una solicitud de amistad."</string>
+    <string name="Select_Friend">"Elige un Amigo"</string>
+    <string name="Failed_to_send_mail_">"No se pudo enviar el correo."</string>
     <string name="In_Game_Mail">"Correo del Juego"</string>
-    <string name="Nav_Buttons_">"Botones Chat/desafíos:"</string>
-    <string name="account_warning">"¡Nunca compartas la contraseña de la cuenta o información personal con nadie!"</string>
+    <string name="Nav_Buttons_">"Botones de Nav.:"</string>
+    <string name="account_warning">"¡Nunca compartas la contraseña de la cuenta o información personal con nadie por ningún motivo!"</string>
     <string name="Clan_Hero">"Héroe del Clan"</string>
     <string name="Win_1000_Clan_Wars">"Gana 1,000 Guerras de Clanes"</string>
     <string name="NAME_COLOR">"COLOR DEL NOMBRE"</string>
     <string name="name_color_instructions">"Selecciona los caracteres que deseas cambiar y luego selecciona el color para cambiarlos."</string>
-    <string name="Cannot_change_this_character_">"No se puede cambiar este carácter"</string>
+    <string name="Cannot_change_this_character_">"No se puede cambiar este carácter."</string>
     <string name="ZOMBIE_APOCALYPSE">"APOCALIPSIS ZOMBIE"</string>
     <string name="Survive_a_Zombie_Apocalypse">"Sobrevive a un apocalipsis zombie"</string>
     <string name="ZA">"AZ"</string>


### PR DESCRIPTION
So many changes to Latin American Spanish that were necessary at my sight.

### Why were these lines changed?
Here are the reasons I've changed all these lines, in number order. All these changes are based on the [English values file](https://github.com/simplicialsoftware/nebulous-translations/blob/main/res/values/strings.xml).

- **Lines from 5 to 8**
  Should be more natural and best-suitable to the grammar.

- **Line 30 and 32**
  Missing period.

- **Line 39**
  Unnecessary space.

- **Lines 41, 42 and 52**
  Missing period.

- **Line 58**
  Should be more natural by including `en:`.

- Line 69
  It was not necessarily incorrect, but I've made it more natural by making it a verb instead.

- **Line 98**
  Length was too long.

- **Lines 101 and 102**
  Included a comma to improve readability; changed from  "utilizar" to "usar" as it's more commonly used in Latin America.

- **Line 104**
  The quotes were not actually appearing so I've included a reversed solidus (`\`) on both.

- **Lines 132 and 133, 139 and 141**
  Improve readability.

- **Line 276**
  Translation from "ELDER" to "VETERANO" was not really accurate; "ANCIANO" fits better here. There's already a "VET" here, so this change should avoid confusion.

- **Line 279**
  Improved accuracy.

- **Lines 289-296**
  Missing periods and capital C in "Clan" was unnecessary.

- **Lines 299, 300, 307-314**
  Improved readability.

- **Line 316**
  Missing period.

- **Line 320**
  Unnecessary exclamation mark.

- **Line 324, 329 and 333**
  Improved accuracy.

- **Lines 337 and 338**
  Unnecessry capitalisation.

- **Line 345**
  Missing period 

- **Line 346**
  Improved readability by including a comma.

- **Line 379**
  The G should be capitalised.

- **Line 394**
  Missing period.

- **Line 397**
  Improved accuracy.

- **Line 426**
  Improved readability; "reconectarte" was changed by my mistake and I've just noticed.

- **Line 433**
  Missing period.

- **Line 438**
  Improved readability and accuracy.

- **Line 444**
  The H should be capitalised.

- **Line 449**
  Missing period.

- **Line 460**
  Improved accuracy.

- **Line 474**
  Same aa line 104.

- **Line 479**
  Missing period.

- **Lines 485, 486 and 487**
  Missing periods; improved accuracy.

- **Line 507**
  More natural sentence.

- **Line 528**
  Corrected typo.

- **Lines 533, 534 and 535**
  Missing periods.

- **Lines 548 and 550**
  Improved accuracy.

- **Line 559**
  String line was unnecessarily long, since "Otro" already says it all.

- **Line 566 and 569**
   Improved accuracy.

- **Line 576**
  For some reason, `candies_` was capitalised and was not equal to the English values. Missing period.

- **Line 578**
  Structure was reversed; it was actually translated from "Opacity Control" or "Control of Opacity", instead of "Control Opacity" (the correct text).

- **Lines 580-586**
  Missing punctuations; "Máximo de jugadores" is the accurate translation for max players, rather than "Máximos jugadores" which does not make sense.

- **Line 593**
  Missing period.

- **Line 599**
  The P should be capitalised.

- **Line 600**
  I've made it more clear now.

- **Line 606, 615 and 627**
  Missing period.

- **Line 643**
  Just like how it happened to `candies_`, the R in `raindrops_` was capitalised. As a consequence, I was confused and mistakenly left G and L capitalised, too. Please check the English strings file and compare – these changes were needed at all.

- **Line 650**
  The M should be capitalised.

- **Line 651**
  Missing period.

- **Line 654**
  Exclamation was not needed.

- **Line 655**
  Missing inverted exclamation at the start.

- **Lines 656 and 658**
  Improved accuracy.

- **Line 670**
  Missing period; the N should not be capitalised.

- **Line 671**
  Missing period.

- **Line 678**
  Fixed the same issue as of `candies_` and `raindrops_`.

- **Line 687**
  Missing period.

- **Lines 696-701**
  Missing periods and capitalised letters.

- **Lines 710**
  Missing period.

- **Lines 711**
  Improved accuracy.

- **Line 721**
  I've made it more natural, since it refers to a *date* of something that will end.

- **Line 731**
  I've made it more clear for users.

- **Line 748-751**
  Improved accuracy.

- **Line 775, 780, 782-785**
  Improved readaibility and accuracy; I've accidentally left the `DELETE` string as lowercase, but I'll correct it as soon as possible.

- **Line 787**
  String was unnecessarily long; "Nav." already shares the meaning of "Navegación" (Nav Buttons, Navigation Buttons), which can also refer to chat and mail ones.

- **Line 788**
  I've made it more clear for users.

- **Line 793**
  Missing period.
-----

⚠️ All the changes were made based on my knowledge and there may contain mistakes. Therefore, please feel free to request changes if needed.

⚠️ I greatly recommend developer to take another view into the in-game Latin American Spanish, because all the texts are still translated from `values-es`, and not from `values-b+es+r419`.

Thanks ^^