### PR TITLE
Update to the values-pt-rBR strings file.

### DIFF
--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -29,7 +29,7 @@
     <string name="WAIT">"AGUARDE…"</string>
     <string name="Must_Specify_Name_">"É Necessário Especificar um Nome."</string>
 
-    <string name="Content_rating_of_the_app_may_change_when_finding_groups_">"A classificação indicativa do aplicativo poderá mudar quando encontrar grupos."</string>
+    <string name="Content_rating_of_the_app_may_change_when_finding_groups_">"A classificação indicativa do aplicativo poderá mudar ao encontrar grupos."</string>
 
     <string name="_Rank_">" Posição "</string>
     <string name="_Alias_">" Apelido "</string>


### PR DESCRIPTION
Here are some few corrections to Brazilian Portuguese.

- **Lines 32 and 883: “Content rating”**
  “Classificação indicativa” is often used rather than “Classificação de conteúdo” (which is a literal translation). Also, to make the sentence more natural, I changed it from “pode” (can) to “poderá” (may) – this is named **<u>Future Tense of Present</u>**. Also changed from “quando” (when) to “ao” (when) to better fit within the grammatical rule.

- **Line 606**
  “Detalhes do erro copiado” (Details of **copied** error) is inaccurate, then it has been changed to “Detalhes do erro copiados” (**Copied** error **details**) – the last word should be plural so it matches better.