### PR TITLE
Update strings.xml

### DIFF
--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -148,7 +148,7 @@
 
     <string name="Dot_Nibbler">"Roedor de puntos"</string>
     <string name="Dot_Muncher">"Absorbe puntos"</string>
-    <string name="Dot_Eater">"Come puntos"</string>
+    <string name="Dot_Eater">"Comedor de puntos"</string>
     <string name="Dot_Gulper">"Tragón de puntos"</string>
     <string name="Dot_Gobbler">"Engulle puntos"</string>
     <string name="Dot_Devourer">"Devorador de puntos"</string>


### PR DESCRIPTION
ID: 24010036

Razón: la traducción correcta del inglés al español del comando "Dot_Eater" es "Comedor de puntos", no "Come puntos".