### PR TITLE
Update Language Indonesia (IN)

### DIFF
--- a/res/values-in/strings.xml
+++ b/res/values-in/strings.xml
@@ -228,7 +228,7 @@
 
     <string name="JOIN_CLAN">"GABUNG KLAN"</string>
     <string name="JOIN_RANDOM_CLAN">"GABUNG KLAN SECARA ACAK"</string>
-    <string name="LEAVE_CLAN">"TINGGALKAN KLAN"</string>
+    <string name="LEAVE_CLAN">"KELUAR KLAN"</string>
     <string name="INVITE_MEMBER">"UNDANG ANGGOTA"</string>
     <string name="REMOVE_MEMBER">"HAPUS ANGGOTA"</string>
 


### PR DESCRIPTION
The word "Meninggalkan" is incorrect cause Meninggalkan is for Leaving not leave I'm from Indonesia the word leave in here is "Keluar" maybe something wrong with previous translation

My Nebulous ID : 20044504