### PR TITLE
Fix missing quotation mark in Portuguese translation

### DIFF
--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -327,7 +327,7 @@
     <string name="COMPLETE">"COMPLETO"</string>
     <string name="INCOMPLETE">"INCOMPLETO"</string>
     <string name="Win_a_FFA_Time_Game">"Vencer um Jogo de FFA com Tempo"</string>
-    <string name="Win_a_CTF_Game">"Vencer um Jogo de CAB</string>
+    <string name="Win_a_CTF_Game">"Vencer um Jogo de CAB"</string>
     <string name="Win_a_Soccer_Game">"Vencer um Jogo de Futebol"</string>
     <string name="Win_a_Survival_Game">"Vencer um Jogo de Sobrevivência"</string>
     <string name="Win_a_Teams_Time_Game">"Vencer um Jogo de Equipes com Tempo"</string>


### PR DESCRIPTION
Game ID: 10367545
Fixed a missing closing quotation mark in the Portuguese translation for Win_a_CTF_Game in strings.xml.